### PR TITLE
Issue#11 Fix chapter name: replace placeholder with Boston

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
                 </div>
                 <div class="col-sm-12 col-md-7">
                     <p>
-                        We're the [FILL CHAPTER NAME IN] chapter of PyLadies, an international mentorship group for marginalized genders, such as but not limited to non-binary people, trans people, and women in tech.
+                        We're the Boston chapter of PyLadies, an international mentorship group for marginalized genders, such as but not limited to non-binary people, trans people, and women in tech.
                     </p>
                     <p>
                         We host monthly <a href=[FILL IN MEETUP PAGE] target="_blank">events</a>,


### PR DESCRIPTION
This replaces the placeholder text "[FILL CHAPTER NAME IN]" with "Boston" on the homepage 

Please let me know if anything else I can improve or need to be fixed.


