### PR TITLE
Fix skyline image credit as requested (issue #16)

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 
 
         <div class="skyline"></div>
-        <span class="aurimas"><a href="https://www.flickr.com/photos/needoptic/13939643805/in/gallery-ebarney-72157686347209143/">Aurimas</a> via Flickr Creative Commons</span>
+        <span class="aurimas"><a href="https://unsplash.com/@muzammilo" target="_blank">Muzammil Soorma</a> via Unsplash</span>
         <div class="container-fluid">
             <div class="row" id="pyladies">
                 <h1 class="col-sm-12 text-center">PyLadies Boston</h1>


### PR DESCRIPTION
## Summary
Fixes the skyline image credit in `index.html` to correctly attribute the photographer Muzammil Soorma via Unsplash.

Closes #16

## Have you confirmed the website builds locally with your changes?
- [x] Yes
- [ ] No