### PR TITLE
Clean connect section Fixes #12

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,18 +144,24 @@
                     <h4>Connect</h4>
                     <img src="./images/line.svg" class="hr-squiggle">
                     <p>
+                        Stay in touch with PyLadies Boston through any of the channels below.
+                    </p>
+                    <p>
+                        <strong>Announcements & events:</strong>
                         Follow us on <a href="https://www.linkedin.com/company/pyladies-boston" target="_blank">LinkedIn</a>
-                        or join our <a href="https://www.meetup.com/pyladies-boston/events/" target="_blank">
-                        Meetup group</a> to get announcements and find out about
-                        upcoming events.
+                        or join our <a href="https://www.meetup.com/pyladies-boston/events/" target="_blank">Meetup group</a>
+                        to hear about upcoming events.
                     </p>
                     <p>
-                        To connect with other PyLadies members through Slack, join
-                        <a href="http://slackin.pyladies.com" target="_blank">slackin.pyladies.com</a>
-                        and sign up for the <code>#boston</code> channel.
+                        <strong>Community chat:</strong>
+                        Join <a href="http://slackin.pyladies.com" target="_blank">slackin.pyladies.com</a>
+                        and sign up for the <code>#boston</code> channel to connect with other PyLadies members.
                     </p>
                     <p>
-                        If you would like to give a tech talk, demo, or workshop, or if your company is interested in hosting an event, reach out to us on <a href="https://www.meetup.com/pyladies-boston/" target="_blank">Meetup</a> or connect with the organizers on Slack at <a href="http://slackin.pyladies.com" target="_blank">#boston</a>.
+                        <strong>Speak or host:</strong>
+                        If you would like to give a tech talk, demo, or workshop, or if your company is interested in hosting an event,
+                        reach out to us on <a href="https://www.meetup.com/pyladies-boston/" target="_blank">Meetup</a>
+                        or connect with the organizers on Slack in <code>#boston</code>.
                     </p>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 
 
         <div class="skyline"></div>
-        <span class="aurimas"><a href="https://www.flickr.com/photos/needoptic/13939643805/in/gallery-ebarney-72157686347209143/">Aurimas</a> via Flickr Creative Commons</span>
+        <span class="aurimas"><a href="https://unsplash.com/@muzammilo" target="_blank">Muzammil Soorma</a> via Unsplash</span>
         <div class="container-fluid">
             <div class="row" id="pyladies">
                 <h1 class="col-sm-12 text-center">PyLadies Boston</h1>


### PR DESCRIPTION
## Summary
Improves readability of the Connect section by breaking the text into clearer paragraphs and adding labels for each communication channel (events, community chat, speaking/hosting).


 
This addresses issue #12 where the section was described as a wall of text.

## Have you confirmed the website builds locally with your changes?

- [x] Yes
- [ ] No

 Fixes #12